### PR TITLE
Add environment variable for web worker timeout config in bin/docker-entrypoint

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -20,7 +20,7 @@ scheduler() {
 }
 
 server() {
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} -t${REDASH_WEB_WORKER_TIMEOUT:-30} redash.wsgi:app
 }
 
 create_db() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description
Add new environment variable for web worker timeout config:
`REDASH_WEB_WORKER_TIMEOUT`(in seconds)
this is used in `bin/docker-entry` file for gunicorn command line argument.
